### PR TITLE
Remove & Replace buttons

### DIFF
--- a/PyMca5/PyMcaCore/TiledDataSource.py
+++ b/PyMca5/PyMcaCore/TiledDataSource.py
@@ -147,6 +147,8 @@ class TiledDataSource(QSource.QSource):
     def isUpdated(self,key):
         pass
 
+    def get_current_selections(self):
+        pass
 
 def _is_Tiled_Source(sourceName):
     try:

--- a/PyMca5/PyMcaCore/TiledDataSource.py
+++ b/PyMca5/PyMcaCore/TiledDataSource.py
@@ -147,9 +147,6 @@ class TiledDataSource(QSource.QSource):
     def isUpdated(self,key):
         pass
 
-    def get_current_selections(self):
-        pass
-
 def _is_Tiled_Source(sourceName):
     try:
         if (

--- a/PyMca5/PyMcaGui/io/QSourceSelector.py
+++ b/PyMca5/PyMcaGui/io/QSourceSelector.py
@@ -156,7 +156,7 @@ class QSourceSelector(qt.QWidget):
         _logger.debug(f"*** {self.tiledWidget.dialog.model.node_path_parts = }")
         self.tiledWidget.model.table_changed.emit(self.tiledWidget.dialog.model.node_path_parts)
 
-        current_catalog = self.tiledWidget.dialog.model.client[*self.tiledWidget.dialog.model.selected_catalog_path]
+        current_catalog = self.tiledWidget.dialog.model.client[self.tiledWidget.dialog.model.selected_catalog_path]
         _logger.debug(f"@@@ {current_catalog = }")
         _logger.debug(f"{current_catalog.uri = }")
         # url = "https://tiled-demo.blueskyproject.io/api"
@@ -375,6 +375,9 @@ class QSourceSelector(qt.QWidget):
         ddict["combokey"] = key
         ddict["sourcelist"] = self.mapCombo[key]
         self.sigSourceSelectorSignal.emit(ddict)
+
+    def get_current_selection(self):
+        pass
 
 def test():
     a = qt.QApplication(sys.argv)

--- a/PyMca5/PyMcaGui/io/QSourceSelector.py
+++ b/PyMca5/PyMcaGui/io/QSourceSelector.py
@@ -156,7 +156,7 @@ class QSourceSelector(qt.QWidget):
         _logger.debug(f"*** {self.tiledWidget.dialog.model.node_path_parts = }")
         self.tiledWidget.model.table_changed.emit(self.tiledWidget.dialog.model.node_path_parts)
 
-        current_catalog = self.tiledWidget.dialog.model.client[self.tiledWidget.dialog.model.selected_catalog_path]
+        current_catalog = self.tiledWidget.dialog.model.client[*self.tiledWidget.dialog.model.selected_catalog_path]
         _logger.debug(f"@@@ {current_catalog = }")
         _logger.debug(f"{current_catalog.uri = }")
         # url = "https://tiled-demo.blueskyproject.io/api"

--- a/PyMca5/PyMcaGui/io/QSourceSelector.py
+++ b/PyMca5/PyMcaGui/io/QSourceSelector.py
@@ -376,9 +376,6 @@ class QSourceSelector(qt.QWidget):
         ddict["sourcelist"] = self.mapCombo[key]
         self.sigSourceSelectorSignal.emit(ddict)
 
-    def get_current_selection(self):
-        pass
-
 def test():
     a = qt.QApplication(sys.argv)
     #new access

--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -513,7 +513,7 @@ class QTiledWidget(QWidget):
                         'y': channel_sel['y'],
                         'm': channel_sel['m'],
                         'Channel List': channel_sel['Data Channel List'],
-                        'LabelNames': channel_sel['Data Channel List']
+                        'LabelNames': channel_sel['Data Channel List'],
                     },
                     'scanselection': True,
                 }
@@ -525,8 +525,56 @@ class QTiledWidget(QWidget):
 
         # Emit the updated list after removal
         if emit and len(sel_list):
-            print("This is being triggered")
             self.sigRemoveSelection.emit(sel_list)
+        else:
+            _logger.debug("No selections left after removal.")
+
+    def _on_replace_clicked(self, *, emit=True):
+        """Replace old plots in scan window with selected plots"""
+        _logger.debug("QTiledWidget._on_replace_clicked()...")
+            # Get the selected item from the catalog table
+        selected = self.catalog_table.selectedItems()
+        if not selected:
+            return
+
+        # Extract the selected node path
+        item = selected[1]
+        selected_node_path_parts = self.model.node_path_parts + (item.text(),)
+
+        sel_list = []
+
+        # Get the channel selection from the data channel table
+        channel_sel = self.data_channel_table.getChannelSelection()
+        _logger.debug(f'{channel_sel = }')
+        _logger.debug(f'{self.model.node_path_parts = }')
+
+        # Create a selection entry
+        sel = {}
+        if len(channel_sel['Data Channel List']):
+            if len(channel_sel['y']):
+                sel = {
+                    'SourceName': self.data.sourceName,
+                    'SourceType': self.data.sourceType,
+                    'Key': selected_node_path_parts,
+                    'legend': '/'.join(selected_node_path_parts),
+                    'selection': {
+                        'x': channel_sel['x'],
+                        'y': channel_sel['y'],
+                        'm': channel_sel['m'],
+                        'Channel List': channel_sel['Data Channel List'],
+                        'LabelNames': channel_sel['Data Channel List'],
+                    },
+                    'scanselection': True,
+                }
+                sel_list.append(sel)
+
+        if not sel:
+            _logger.debug("No valid selection to remove.")
+            return
+
+        # Emit the updated list after replace
+        if emit and len(sel_list):
+            self.sigReplaceSelection.emit(sel_list)
         else:
             _logger.debug("No selections left after removal.")
     
@@ -581,6 +629,7 @@ class QTiledWidget(QWidget):
         self.open_button.clicked.connect(self._on_load)
         self.add_button.clicked.connect(self._on_add_clicked)
         self.remove_button.clicked.connect(self._on_remove_clicked)
+        self.replace_button.clicked.connect(self._on_replace_clicked)
 
 
 # # Command Buttons Connections

--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -401,7 +401,7 @@ class QTiledWidget(QWidget):
 
         if self.dialog.model.client is None:
             return
-        self.model.url = self.dialog.model.client[*self.dialog.model.selected_catalog_path].uri
+        self.model.url = self.dialog.model.client[self.dialog.model.selected_catalog_path].uri
 
         _logger.debug(f"{self.model.url = }")
 
@@ -464,7 +464,9 @@ class QTiledWidget(QWidget):
                     'selection': {'x': channel_sel['x'],
                                   'y': channel_sel['y'],
                                   'm': channel_sel['m'],
-                                  'Channel List': channel_sel['Data Channel List']},
+                                  'Channel List': channel_sel['Data Channel List'],
+                                  'LabelNames': channel_sel['Data Channel List'],
+                                  },
                     'scanselection': True,
                     }
                 sel_list.append(sel)
@@ -477,7 +479,57 @@ class QTiledWidget(QWidget):
                 self.sigAddSelection.emit(sel_list)
             else:
                 return sel_list
+            
+    def _on_remove_clicked(self, *, emit=True):
+        """Remove selected plot from ScanWindow."""
+        _logger.debug("QTiledWidget._on_remove_clicked()...")
+            # Get the selected item from the catalog table
+        selected = self.catalog_table.selectedItems()
+        if not selected:
+            return
 
+        # Extract the selected node path
+        item = selected[1]
+        selected_node_path_parts = self.model.node_path_parts + (item.text(),)
+
+        sel_list = []
+
+        # Get the channel selection from the data channel table
+        channel_sel = self.data_channel_table.getChannelSelection()
+        _logger.debug(f'{channel_sel = }')
+        _logger.debug(f'{self.model.node_path_parts = }')
+
+        # Create a selection entry
+        sel = {}
+        if len(channel_sel['Data Channel List']):
+            if len(channel_sel['y']):
+                sel = {
+                    'SourceName': self.data.sourceName,
+                    'SourceType': self.data.sourceType,
+                    'Key': selected_node_path_parts,
+                    'legend': '/'.join(selected_node_path_parts),
+                    'selection': {
+                        'x': channel_sel['x'],
+                        'y': channel_sel['y'],
+                        'm': channel_sel['m'],
+                        'Channel List': channel_sel['Data Channel List'],
+                        'LabelNames': channel_sel['Data Channel List']
+                    },
+                    'scanselection': True,
+                }
+                sel_list.append(sel)
+
+        if not sel:
+            _logger.debug("No valid selection to remove.")
+            return
+
+        # Emit the updated list after removal
+        if emit and len(sel_list):
+            print("This is being triggered")
+            self.sigRemoveSelection.emit(sel_list)
+        else:
+            _logger.debug("No selections left after removal.")
+    
     def connect_model_signals(self) -> None:
         """Connect dialog slots to model signals."""
         _logger.debug("QTiledWidget.connect_model_signals()...")
@@ -505,6 +557,7 @@ class QTiledWidget(QWidget):
 
         self.model.url_changed.connect(self.model.on_url_changed)
 
+
     def connect_model_slots(self) -> None:
         """Connect model slots to dialog signals."""
         _logger.debug("QTiledWidget.connect_model_slots()...")
@@ -527,6 +580,7 @@ class QTiledWidget(QWidget):
         # )
         self.open_button.clicked.connect(self._on_load)
         self.add_button.clicked.connect(self._on_add_clicked)
+        self.remove_button.clicked.connect(self._on_remove_clicked)
 
 
 # # Command Buttons Connections

--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -401,7 +401,7 @@ class QTiledWidget(QWidget):
 
         if self.dialog.model.client is None:
             return
-        self.model.url = self.dialog.model.client[self.dialog.model.selected_catalog_path].uri
+        self.model.url = self.dialog.model.client[*self.dialog.model.selected_catalog_path].uri
 
         _logger.debug(f"{self.model.url = }")
 

--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -465,7 +465,7 @@ class QTiledWidget(QWidget):
                                   'y': channel_sel['y'],
                                   'm': channel_sel['m'],
                                   'Channel List': channel_sel['Data Channel List'],
-                                  'LabelNames': channel_sel['Data Channel List'],
+                                  'LabelNames': channel_sel['Data Channel List'].copy(),
                                   },
                     'scanselection': True,
                     }
@@ -604,7 +604,6 @@ class QTiledWidget(QWidget):
             self._rebuild_current_path_layout()
 
         self.model.url_changed.connect(self.model.on_url_changed)
-
 
     def connect_model_slots(self) -> None:
         """Connect model slots to dialog signals."""

--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -513,7 +513,7 @@ class QTiledWidget(QWidget):
                         'y': channel_sel['y'],
                         'm': channel_sel['m'],
                         'Channel List': channel_sel['Data Channel List'],
-                        'LabelNames': channel_sel['Data Channel List'],
+                        'LabelNames': channel_sel['Data Channel List'].copy(),
                     },
                     'scanselection': True,
                 }
@@ -562,7 +562,7 @@ class QTiledWidget(QWidget):
                         'y': channel_sel['y'],
                         'm': channel_sel['m'],
                         'Channel List': channel_sel['Data Channel List'],
-                        'LabelNames': channel_sel['Data Channel List'],
+                        'LabelNames': channel_sel['Data Channel List'].copy(),
                     },
                     'scanselection': True,
                 }

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -467,6 +467,7 @@ class ScanWindow(PlotWindow.PlotWindow):
 
         removelist = []
         for sel in sellist:
+            print(f"From scan window {sel}")
             source = sel['SourceName']
             key = sel['Key']
             if not ("scanselection" in sel):
@@ -475,7 +476,7 @@ class ScanWindow(PlotWindow.PlotWindow):
                 continue
             if not sel["scanselection"]:
                 continue
-            if len(key.split(".")) > 2:
+            if isinstance(key, str) and len(key.split(".")) > 2:
                 continue
 
             legend = sel['legend'] # expected form sourcename + scan key
@@ -486,7 +487,6 @@ class ScanWindow(PlotWindow.PlotWindow):
                             for index in sel['selection']['y']:
                                 removelist.append(legend +" "+\
                                                   sel['selection'][lName][index])
-
         if len(removelist):
             self.removeCurves(removelist)
 

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -467,7 +467,6 @@ class ScanWindow(PlotWindow.PlotWindow):
 
         removelist = []
         for sel in sellist:
-            print(f"From scan window {sel}")
             source = sel['SourceName']
             key = sel['Key']
             if not ("scanselection" in sel):
@@ -511,13 +510,14 @@ class ScanWindow(PlotWindow.PlotWindow):
 
         doit = False
         for sel in sellist:
+            key = sel['Key']
             if not ("scanselection" in sel):
                 continue
             if sel['scanselection'] == "MCA":
                 continue
             if not sel["scanselection"]:
                 continue
-            if len(sel["Key"].split(".")) > 2:
+            if isinstance(key, str) and len(key.split(".")) > 2:
                 continue
             dataObject = sel['dataobject']
             if dataObject.info["selectiontype"] == "1D":


### PR DESCRIPTION
The "REMOVE" and "REPLACE" buttons are now working for the Tiled Browser. The data channels that are plotted in the scan window can be unchecked in the data channel table and new selections can be checked, with the changes being reflected in the scan window once the replace button has been clicked.

The _on_remove_clicked function was added to QTiledWidget. In addition the 'LabelNames' key was added to both the _on_add_clicked and _on_remove_clicked function.


_on_replace_clicked function was added and connect_self_signals was modified in QTiledWidget.py. _replaceSelection was modified in ScanWindow.py