### PR TITLE
Use full run ID in run selector table

### DIFF
--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -273,10 +273,10 @@ class QTiledWidget(QWidget):
         items = results
         # Loop over rows, filling in keys until we run out of keys.
         start = 1 if self.model.node_path_parts else 0
-        for row_index, (key, value) in zip(
+        for row_index, (run_uid, run_info) in zip(
             range(start, self.catalog_table.rowCount()), items
         ):
-            start_doc = value.start
+            start_doc = run_info.start
             scan_id = start_doc.get("scan_id")
             plan_name = start_doc.get("plan_name")
             start_time = start_doc.get("start_datetime")
@@ -284,7 +284,7 @@ class QTiledWidget(QWidget):
                 start_time = datetime.fromtimestamp(start_doc.get("time")).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
             else:
                 start_time = datetime.fromisoformat(start_time).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-            stop_doc = value.stop
+            stop_doc = run_info.stop
             if stop_doc is None:
                 stop_doc = {}
             exit_status = stop_doc.get("exit_status")
@@ -298,7 +298,7 @@ class QTiledWidget(QWidget):
             else:
                 stop_time = datetime.fromtimestamp(stop_time).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
-            family = value.item["attributes"]["structure_family"]
+            family = run_info.item["attributes"]["structure_family"]
 
             if family == StructureFamily.container:
                 # Change the icon for BlueskyRuns so it doesn't look like
@@ -320,7 +320,7 @@ class QTiledWidget(QWidget):
             )
             # first 8 chars of uid
             self.catalog_table.setItem(
-                row_index, 1, QTableWidgetItem(key[:8])
+                row_index, 1, QTableWidgetItem(run_uid)
             )
             # plan_name
             self.catalog_table.setItem(
@@ -377,7 +377,7 @@ class QTiledWidget(QWidget):
             self._clear_metadata()
             return
         # selected[0] is scan_id
-        # selected[1] is partial uid
+        # selected[1] is the run uid
         item = selected[1]
         child_node_path = item.text()
         model.on_item_selected(child_node_path)

--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -318,9 +318,12 @@ class QTiledWidget(QWidget):
             self.catalog_table.setItem(
                 row_index, 0, QTableWidgetItem(icon, str(scan_id))
             )
-            # first 8 chars of uid
+            # Bluesky run UID
+            uid_item = QTableWidgetItem()
+            uid_item.setData(Qt.UserRole, run_uid)  # Store the full UID
+            uid_item.setData(Qt.DisplayRole, run_uid[:8])  # Partial UID
             self.catalog_table.setItem(
-                row_index, 1, QTableWidgetItem(run_uid)
+                row_index, 1, uid_item
             )
             # plan_name
             self.catalog_table.setItem(


### PR DESCRIPTION
Displaying a partial run UID in the Run Selector table is easy on the eyes, but 
is not sufficient to use as the path parameter in a Tiled URL. Several runs could start with the same 8 characters; this is the case in <https://tiled-demo.nsls2.bnl.gov/>. This was r[eported in Mattermost](https://mattermost.hzdr.de/bluesky/pl/nesnkdc3rjgebk99tdmgaaurih) by Linus Pithan.

This PR updates the table to use the full UID. It has been verified to work with the BMM catalog in <https://tiled-demo.nsls2.bnl.gov/> where name clashes were found to exist when using the partial UID to navigate the catalog,