### PR TITLE
Send the full run UID to Tiled client

### DIFF
--- a/PyMca5/PyMcaGui/io/QTiledWidget.py
+++ b/PyMca5/PyMcaGui/io/QTiledWidget.py
@@ -382,7 +382,7 @@ class QTiledWidget(QWidget):
         # selected[0] is scan_id
         # selected[1] is the run uid
         item = selected[1]
-        child_node_path = item.text()
+        child_node_path = item.data(Qt.UserRole)  # Full UID, not displayed text
         model.on_item_selected(child_node_path)
 
         self.info_box.setText(model.info_text)


### PR DESCRIPTION
Now that we store the full run UID as UserRole data, we also need to retrieve it as UserRole data -- rather than retrieving the displayed text.